### PR TITLE
CI conf for tests. Invalidate address if HRP is too long

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,9 @@
+dist: bionic
+language: python
+python:
+  - '3.5'
+  - '3.6'
+  - '3.7'
+  - '3.8'
+script:
+  - python -m unittest

--- a/bech32/__init__.py
+++ b/bech32/__init__.py
@@ -67,7 +67,7 @@ def bech32_decode(bech):
         return (None, None)
     bech = bech.lower()
     pos = bech.rfind("1")
-    if pos < 1 or pos + 7 > len(bech):  # or len(bech) > 90:
+    if pos < 1 or pos > 83 or pos + 7 > len(bech):  # or len(bech) > 90:
         return (None, None)
     if not all(x in CHARSET for x in bech[pos + 1 :]):
         return (None, None)


### PR DESCRIPTION
- Add travis configuration for running tests
- Fix a failing test: Invalidate bech32 address if human readable part is over 83 characters